### PR TITLE
Two patches

### DIFF
--- a/JustParse.cabal
+++ b/JustParse.cabal
@@ -1,5 +1,5 @@
 name:                JustParse
-version:             2.1
+version:             2.2
 synopsis:            A simple and comprehensive Haskell parsing library
 description:         A simple and comprehensive Haskell parsing library
 homepage:            https://github.com/grantslatton/JustParse

--- a/JustParse.cabal
+++ b/JustParse.cabal
@@ -1,5 +1,5 @@
 name:                JustParse
-version:             2.2
+version:             2.2.1
 synopsis:            A simple and comprehensive Haskell parsing library
 description:         A simple and comprehensive Haskell parsing library
 homepage:            https://github.com/grantslatton/JustParse

--- a/src/Data/JustParse.hs
+++ b/src/Data/JustParse.hs
@@ -99,3 +99,4 @@ parseOnly p s =
     case finalize (parse (greedy p) (Open s)) of
         [] -> Nothing
         (Done v _:_) -> Just v
+        (Partial _:_) -> error "parseOnly returned Partial"

--- a/src/Data/JustParse/Char.hs
+++ b/src/Data/JustParse/Char.hs
@@ -72,6 +72,11 @@ space :: Stream s Char =>  Parser s Char
 space = satisfy isSpace
 {-# INLINE space #-}
 
+-- | Parse many spaces.
+spaces :: Stream s Char => Parser s [Char]
+spaces = many space
+{-# INLINE spaces #-}
+
 -- | Parse a lowercase character.
 lower :: Stream s Char =>  Parser s Char
 lower = satisfy isLower
@@ -122,9 +127,9 @@ caseInsensitiveString :: Stream s Char => String -> Parser s String
 caseInsensitiveString = mapM caseInsensitiveChar 
 {-# INLINE caseInsensitiveString #-}
 
--- | Parses until a newline, carriage return + newline, or newline + carriage return.
+-- | Parses until a newline, carriage return, carriage return + newline, or newline + carriage return.
 eol :: Stream s Char => Parser s String
-eol = choice [string "\r\n", string "\n\r", string "\n"]
+eol = choice [string "\r\n", string "\n\r", string "\n", string "\r"]
 {-# INLINE eol #-}
 
 -- | Makes common types such as 'String's into a Stream.

--- a/src/Data/JustParse/Char.hs
+++ b/src/Data/JustParse/Char.hs
@@ -19,6 +19,7 @@ module Data.JustParse.Char (
     latin1,
     control,
     space,
+    spaces,
     lower,
     upper,
     alpha,

--- a/src/Data/JustParse/Combinator.hs
+++ b/src/Data/JustParse/Combinator.hs
@@ -25,6 +25,7 @@ module Data.JustParse.Combinator (
     test,
     try,
     (<|>),
+    assertNotP,
 
     -- * Token Parsers
     anyToken,
@@ -561,3 +562,8 @@ perm_ ps =
         (i, r) <- select_ ps
         M.liftM (r:) (perm_ (let (a,b) = splitAt i ps in a ++ tail b)) 
 {-# INLINE perm_ #-}
+
+-- | Negate a parser.
+assertNotP :: Stream s e => Parser s a -> Parser s ()
+assertNotP p = optional p >>= guard . maybe True (const False)
+{-# INLINE assertNotP #-}

--- a/src/Data/JustParse/Language.hs
+++ b/src/Data/JustParse/Language.hs
@@ -31,28 +31,26 @@ import Data.Maybe ( isJust, fromMaybe )
 import Data.List ( intercalate )
 
 -- | @regex@ takes a regular expression in the form of a 'String' and,
--- if the regex is valid, returns a 'Parser' that parses that regex.
--- If the regex is invalid, it returns a Parser that will always fail.
--- The returned parser is greedy.
-regex :: Stream s Char => String -> Parser s Match
-regex = greedy . fromMaybe mzero . parseOnly regular
+-- if the regex is valid, returns a greedy 'Parser' that parses that regex.
+-- If the regex is invalid, it returns Nothing.
+regex :: Stream s Char => String -> Maybe (Parser s Match)
+regex = liftM greedy . regex_
 {-# INLINE regex #-}
 
 -- | Like 'regex', but returns a branching (non-greedy) parser.
-regex_ :: Stream s Char => String -> Parser s Match
-regex_ = fromMaybe mzero . parseOnly regular
+regex_ :: Stream s Char => String -> Maybe (Parser s Match)
+regex_ = parseOnly (regular <* eof)
 {-# INLINE regex_ #-}
 
 -- | The same as 'regex', but only returns the full matched text.
-regex' :: Stream s Char => String -> Parser s String
-regex' = liftM matched . regex 
+regex' :: Stream s Char => String -> Maybe (Parser s String)
+regex' = liftM (liftM matched) . regex
 {-# INLINE regex' #-}
 
 -- | The same as 'regex_', but only returns the full matched text.
-regex_' :: Stream s Char => String -> Parser s String
-regex_' = liftM matched . regex_
+regex_' :: Stream s Char => String -> Maybe (Parser s String)
+regex_' = liftM (liftM matched) . regex_
 {-# INLINE regex_' #-}
-
 
 -- | The result of a 'regex'
 data Match = 


### PR DESCRIPTION
The first commit adds `regex` variants that return Nothing when they fail to parse the regular expression.

The second extends the regex parser with two lookahead assertions: `(?=expression)` and `(?!expression)`.
I also added a combinator that creates a negative assertion of a parser.
